### PR TITLE
Manage Backuppc clients & multi OS support (Ubuntu & Centos)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,14 @@ roles:
 You can test this role by using the provided Vagrant file in ./tests
 
 ```bash
-bacuppc/tests$ vagrant up
-bacuppc/tests$ vagrant ssh
+bacuppc/tests$ vagrant up <os>
+bacuppc/tests$ vagrant ssh <os>
 ```
+
+For <os>, you can choose:
+* ubuntu-trusty
+* ubuntu-boinic
+* centos7 
 
 ## License ##
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,28 @@ is welcomed and can be done via
 - Tested on Mac OS X with Ansible 1.5.
 - Tested on Ubuntu Precise with Ansible 2.2.1.0
 
+## Variables ##
+see defaults/main.yml for variables to overwrite and their explainations
+
+Example role include:
+```
+vars:
+  - backuppc_url: 'http://some.domain.tld'
+  - backuppc_hosts: [
+     { name: 'some.host.tld', os: 'linux', type: 'rsync' }
+     { name: 'other.host.tld', os: 'linux', type: 'rsync' }
+   ]
+ - backuppc_users: [ 
+     { name: 'backuppc', pass: 'secret' }
+   ]
+ - backuppc_manage_hosts: yes
+ 
+roles:
+  - backuppc
+
+    }
+```
+
 ## Tests ##
 You can test this role by using the provided Vagrant file in ./tests
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ is welcomed and can be done via
 
 ## Requirements & Dependencies ##
 - Tested on Mac OS X with Ansible 1.5.
-- Tested on Ubuntu Precise with Ansible 2.2.1.0
+- Tested on Ubuntu Precise with Ansible 2.2.x and 2.5.0
 
 ## Variables ##
 see defaults/main.yml for variables to overwrite and their explainations

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ bacuppc/tests$ vagrant ssh <os>
 
 For <os>, you can choose:
 * ubuntu-trusty
+* ubuntu-xenial
 * ubuntu-boinic
 * centos7 
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,26 +1,11 @@
 ---
 backuppc_url: 'http://localhost'
 backuppc_domain: 'localhost'
-<<<<<<< HEAD
 backuppc_email_domain: 'example.com'
+backuppc_email_from_username: "backuppc@{{ backuppc_email_domain }}"
 backuppc_hosts: [] # contains a list of: name, os and type (also optional ip_address and key) attributes.
 backuppc_users:
   -
     name: admin
     pass: admin
 backuppc_web_group: "{% if ansible_os_family == 'RedHat' or ansible_os_family == 'Suse' %}nginx{% elif ansible_os_family == 'Debian' %}www-data{% elif ansible_os_family == 'FreeBSD' %}www{% endif %}"
-=======
-backuppc_email_domain: 'newedgeengineering.com'
-backuppc_email_from_username: 'user@newedgeengineering.com'
-
-# contains a list of: name, os and type (also optional contact and user) attributes.
-# backuppc_hosts: [name: 'host', os: 'linux', type: 'rsync', contact: 'backuppc', user: 'user1 user2']
-backuppc_hosts: [
-    { name: 'localhost', os: 'linux', type: 'rsync', user: 'backuppc'}
-]
-
-backuppc_users:
-  -
-    name: backuppc
-    pass: admin
->>>>>>> 5dd5628db5216dad1dd0101cd83f1e2feb58bc5b

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,4 +14,3 @@ backuppc_users:
     name: backuppc
     pass: admin
 backuppc_manage_hosts: no
-backuppc_web_group: "{% if ansible_os_family == 'RedHat' or ansible_os_family == 'Suse' %}nginx{% elif ansible_os_family == 'Debian' %}www-data{% elif ansible_os_family == 'FreeBSD' %}www{% endif %}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,8 +1,9 @@
 ---
 backuppc_domain: 'localhost'
-backuppc_email_domain: 'newedgeengineering.com'
+backuppc_email_domain: 'example.com'
 backuppc_hosts: [] # contains a list of: name, os and type (also optional ip_address and key) attributes.
 backuppc_users:
   -
     name: admin
     pass: admin
+backuppc_web_group: "{% if ansible_os_family == 'RedHat' or ansible_os_family == 'Suse' %}nginx{% elif ansible_os_family == 'Debian' %}www-data{% elif ansible_os_family == 'FreeBSD' %}www{% endif %}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,3 +14,5 @@ backuppc_users:
   -
     name: backuppc
     pass: admin
+
+backuppc_manage_hosts: no

--- a/files/backuppc.sudo
+++ b/files/backuppc.sudo
@@ -1,0 +1,2 @@
+# backuppc
+backuppc  ALL=NOPASSWD: /usr/bin/rsync --server *

--- a/files/hostconfig/example.host.pl
+++ b/files/hostconfig/example.host.pl
@@ -1,0 +1,21 @@
+#
+# example.host config file for backup of everything as user backuppc
+#
+$Conf{XferMethod} = 'rsync';
+
+$Conf{BackupFilesExclude} = {
+  '*' => [
+    '/sys',
+    '/proc',
+    '/cdrom',
+    '/dvd',
+    '/floppy',
+    '/var/lib/backuppc',
+    '/mnt'
+  ]
+};
+
+$Conf{RsyncClientCmd} = '$sshPath -o StrictHostKeyChecking=no -q -x -l backuppc $host sudo $rsyncPath $argList+';
+
+$Conf{RsyncClientRestoreCmd} = '$sshPath -o StrictHostKeyChecking=no -q -x -l backuppc sudo $host $rsyncPath $argList+';
+

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: restart backuppc
-  service: name=backuppc state=restarted
-
-- name: restart apache2
-  service: name=apache2 state=restarted
+  service:
+    name: backuppc
+    enabled: yes
+    state: restarted

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,3 +4,9 @@
     name: backuppc
     enabled: yes
     state: restarted
+
+- name: restart httpd
+  service:
+    name: '{{backuppc_httpd_service_name }}'
+    enabled: yes
+    state: restarted

--- a/tasks/config_hosts.yml
+++ b/tasks/config_hosts.yml
@@ -2,10 +2,10 @@
 - name: create hosts inventory file
   template:
     src: hosts.j2
-    dest: '/etc/backuppc/hosts'
+    dest: '/etc/{{ backuppc_directory }}/hosts'
     mode: 'u=rw,g=r,o=r'
     owner: 'backuppc'
-    group: 'www-data'
+    group: "{{ backuppc_web_group }}"
     backup: yes
   notify:
     - restart backuppc
@@ -16,13 +16,13 @@
 
 - name: create hosts configuration
   template:
-    dest: "/etc/backuppc/{{ item.name }}.pl"
+    dest: "/etc/{{ backuppc_directory }}/{{ item.name }}.pl"
     src: "backuppc-{{ item.os }}-{{ item.type }}.j2"
-    mode: "u=rw,g=r,o="
-    owner: "backuppc"
-    group: "www-data"
+    mode: 'u=rw,g=r,o='
+    owner: 'backuppc'
+    group: "{{ backuppc_web_group }}"
     force: no
-  with_items: "{{ backuppc_hosts }}"
+  with_items: '{{ backuppc_hosts }}'
   notify:
     - restart backuppc
   tags:
@@ -33,8 +33,14 @@
 - name: copy hosts specific configuration file
   copy:
     src: 'hostconfig/'
-    dest: '/etc/backuppc/'
-    mode: "u=rw,g=r,o="
-    owner: "backuppc"
-    group: "www-data"
+    dest: "/etc/{{ backuppc_directory }}/"
+    mode: 'u=rw,g=r,o='
+    owner: 'backuppc'
+    group: "{{ backuppc_web_group }}"
+  notify:
+    - restart backuppc
+  tags:
+    - backuppc
+    - configuration
+    - clients
 

--- a/tasks/config_hosts.yml
+++ b/tasks/config_hosts.yml
@@ -1,0 +1,37 @@
+---
+- name: create hosts inventory file
+  template:
+    src: hosts.j2
+    dest: '/etc/backuppc/hosts'
+    mode: 'u=rw,g=r,o=r'
+    owner: 'backuppc'
+    group: 'www-data'
+    backup: yes
+  notify:
+    - restart backuppc
+  tags:
+    - backuppc
+    - configuration
+    - clients
+
+- name: create hosts configuration
+  template:
+    dest: "/etc/backuppc/{{ item.name }}.pl"
+    src: "backuppc-{{ item.os }}-{{ item.type }}.j2"
+    mode: "u=rw,g=r,o="
+    owner: "backuppc"
+    group: "www-data"
+    force: no
+  with_items: "{{ backuppc_hosts }}"
+  notify:
+    - restart backuppc
+  tags:
+    - backuppc
+    - configuration
+    - clients
+
+- name: copy hosts specific configuration file
+  copy:
+    src: 'hostconfig/'
+    dest: '/etc/backuppc/'
+

--- a/tasks/config_hosts.yml
+++ b/tasks/config_hosts.yml
@@ -34,4 +34,7 @@
   copy:
     src: 'hostconfig/'
     dest: '/etc/backuppc/'
+    mode: "u=rw,g=r,o="
+    owner: "backuppc"
+    group: "www-data"
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -104,7 +104,7 @@
   fetch:
     src: "/var/lib/{{ backuppc_directory }}/.ssh/id_rsa.pub"
     dest: '/tmp/backuppc_ssh.pub'
-  when: backuppc_server_ssh_key|changed
+  when: backuppc_server_ssh_key is changed
   register: ssh_key_fetched
   tags:
     - backuppc

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,7 +8,6 @@
     cache_valid_time: 3600
   with_items:
     - backuppc
-    - apache2
     - rsync
     - python-passlib # ansible htpasswd support
   tags:
@@ -23,12 +22,7 @@
     - backuppc
     - rsync
     - nfs-utils
-    # - nfs-utils-lib
     - bzip2
-    # - samba
-    # - samba-winbind
-    # - samba-winbind-clients
-    # - pam_krb5
     - python-passlib # ansible htpasswd support
   tags:
     - backuppc
@@ -53,7 +47,6 @@
     group: "{{ backuppc_web_group }}"
   notify:
     - restart backuppc
-    - restart apache2
 
 #  host setup
 - name: create hosts

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,42 +1,40 @@
 ---
-# Software installation
-- name: ensure apt packages are installed
-  apt:
-    pkg: "{{item}}"
-    state: latest
-    update_cache: yes
-    cache_valid_time: 3600
-  with_items:
-    - apache2
-    - backuppc
-    - rsync
-    - python-passlib # ansible htpasswd support
-  tags:
-    - backuppc
-    - packages
-  when: ansible_os_family == 'Debian'
+# include variables
+- name: include vars
+  include_vars: '{{ item }}'
+  with_first_found:
+    - files:
+      - '{{ ansible_distribution }}-{{ ansible_distribution_release }}.yml'
+      - '{{ ansible_distribution }}.yml'
+      - '{{ ansible_os_family }}.yml'
+      skip: true
 
-- name: ensure yum packages are installed
-  yum:
-    pkg: "{{item}}"
-  with_items:
-    - backuppc
-    - rsync
-    - nfs-utils
-    - bzip2
-    - python-passlib # ansible htpasswd support
+# Software installation
+- name: ensure EPEL repository
+  package:
+     pkg: 'epel-release'
+     state: latest
   tags:
     - backuppc
     - packages
   when: ansible_os_family == 'RedHat'
 
+- name: ensure packages are installed
+  package:
+    pkg: '{{ item }}'
+    state: present
+  with_items: '{{ backuppc_packages }}'
+  tags:
+    - backuppc
+    - packages
+
 - name: adjust apache2 config
   lineinfile:
-    name: '/etc/apache2/ports.conf'
+    name: '{{ backuppc_httpd_listen_conf }}'
     regexp: '^Listen.*80$'
     line: 'Listen localhost:80'
     state: present
-  notify: restart apache2
+  notify: restart httpd
 
 - name: set pool symlink
   file:
@@ -120,7 +118,6 @@
     owner: 'backuppc'
     group: "{{ backuppc_web_group }}"
     mode: 'u=rw,g=r,o='
-    mode: 0640
   with_items: "{{ backuppc_users }}"
   when: backuppc_users|length > 0
   tags:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,19 +1,23 @@
 ---
 # Software installation
 - name: ensure packages are installed
-  apt: pkg={{item}} state=latest update_cache=yes cache_valid_time=3600
+  apt:
+    name: "{{ item }}"
+    state: latest
+    update_cache: yes
+    cache_valid_time: 3600
   with_items:
-    - backuppc
     - apache2
-    - rsync
+    - backuppc
     - python-passlib # ansible htpasswd support
+    - rsync
   tags:
     - backuppc
     - packages
 
 - name: adjust apache2 config
   lineinfile:
-    name: /etc/apache2/ports.conf
+    name: '/etc/apache2/ports.conf'
     regexp: '^Listen.*80$'
     line: 'Listen localhost:80'
     state: present
@@ -21,60 +25,30 @@
 
 - name: set pool symlink
   file:
-    src=/var/lib/backuppc/pc
-    dest=/etc/backuppc/pc
-    state=link 
-    owner=backuppc
-    group=backuppc
+    src: '/var/lib/backuppc/pc'
+    dest: '/etc/backuppc/pc'
+    owner: 'backuppc'
+    group: 'backuppc'
+    state: link 
 
 # Software configuration
 - name: copy config.pl
   template:
-    src=config.pl.j2
-    dest=/etc/backuppc/config.pl
-    mode="u=rw,g=r,o=r"
-    owner=backuppc
-    group=www-data
+    src: config.pl.j2
+    dest: '/etc/backuppc/config.pl'
+    mode: 'u=rw,g=r,o=r'
+    owner: 'backuppc'
+    group: 'www-data'
+    backup: yes
   notify:
     - restart backuppc
     - restart apache2
 
-# host setup
-- name: create hosts
-  template:
-    src=hosts.j2
-    dest=/etc/backuppc/hosts
-    mode="u=rw,g=r,o=r"
-    owner=backuppc
-    group=www-data
-  notify:
-    - restart backuppc
-  tags:
-    - backuppc
-    - configuration
-    - clients
-
-- name: create hosts configuration
-  template:
-    dest: "/etc/backuppc/{{ item.name }}.pl"
-    src: "backuppc-{{ item.os }}-{{ item.type }}.j2"
-    mode: "u=rw,g=r,o="
-    owner: "backuppc"
-    group: "www-data"
-    backup: yes
-  with_items: "{{ backuppc_hosts }}"
-  notify:
-    - restart backuppc
-  tags:
-    - backuppc
-    - configuration
-    - clients
-
 # ssh key
 - name: generate a ssh key
   user:
-    name=backuppc
-    generate_ssh_key=yes
+    name: 'backuppc'
+    generate_ssh_key: yes
   register: backuppc_server_ssh_key
   tags:
     - backuppc
@@ -83,8 +57,8 @@
 
 - name: fetch generated public ssh key
   fetch:
-    src=/var/lib/backuppc/.ssh/id_rsa.pub
-    dest=/tmp/backuppc_ssh.pub
+    src: '/var/lib/backuppc/.ssh/id_rsa.pub'
+    dest: '/tmp/backuppc_ssh.pub'
   when: backuppc_server_ssh_key|changed
   register: ssh_key_fetched
   tags:
@@ -98,8 +72,8 @@
     path: /etc/backuppc/htpasswd
     name: "{{ item.name }}"
     password: "{{ item.pass }}"
-    owner: "backuppc"
-    group: "www-data"
+    owner: 'backuppc'
+    group: 'www-data'
     mode: 'u=rw,g=r,o='
   with_items: "{{ backuppc_users }}"
   tags:
@@ -107,8 +81,12 @@
     - website
     - credientals
 
+# hosts configuration
+- name: config hosts
+  include: config_hosts.yml
+
 # loop over backuppc_hosts is done inside manage_hosts.yml
-- name: manage hosts
+- name: manage remote hosts
   include: manage_hosts.yml
   when: backuppc_manage_hosts
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 # Software installation
-- name: ensure packages are installed
+- name: ensure apt packages are installed
   apt:
     pkg: "{{item}}"
   with_items:
@@ -12,11 +12,31 @@
   tags:
     - backuppc
     - packages
+  when: ansible_os_family == 'Debian'
+
+- name: ensure yum packages are installed
+  yum:
+    pkg: "{{item}}"
+  with_items:
+    - backuppc
+    - rsync
+    - nfs-utils
+    # - nfs-utils-lib
+    - bzip2
+    # - samba
+    # - samba-winbind
+    # - samba-winbind-clients
+    # - pam_krb5
+    - python-passlib # ansible htpasswd support
+  tags:
+    - backuppc
+    - packages
+  when: ansible_os_family == 'RedHat'
 
 # Software fixes
 - name: add missing $Conf{Ping6Path}
   lineinfile:
-    dest: /etc/backuppc/config.pl
+    dest: "/etc/{{ backuppc_directory }}/config.pl"
     backrefs: yes
     regexp: "^\\$Conf{Ping6Path}"
     line: "$Conf{Ping6Path} = '/bin/ping6';"
@@ -40,7 +60,7 @@
 # Software configuration
 - name: update configuration $Conf{EMailFromUserName}
   lineinfile:
-    dest: /etc/backuppc/config.pl
+    dest: "/etc/{{ backuppc_directory }}/config.pl"
     backrefs: yes
     regexp: "^\\$Conf{EMailFromUserName}"
     line: "$Conf{EMailFromUserName} = 'backuppc@{{ backuppc_domain }}';"
@@ -52,7 +72,7 @@
 
 - name: update configuration $Conf{EMailUserDestDomain}
   lineinfile:
-    dest: /etc/backuppc/config.pl
+    dest: "/etc/{{ backuppc_directory }}/config.pl"
     backrefs: yes
     regexp: "^\\$Conf{EMailUserDestDomain}"
     line: "$Conf{EMailUserDestDomain} = '@{{ backuppc_email_domain }}';"
@@ -62,7 +82,7 @@
 
 - name: update configuration $Conf{CgiURL}
   lineinfile:
-    dest: /etc/backuppc/config.pl
+    dest: "/etc/{{ backuppc_directory }}/config.pl"
     backrefs: yes
     regexp: "^\\$Conf{CgiURL}"
     line: "$Conf{CgiURL} = 'http://backuppc.{{ backuppc_email_domain }}/backuppc/index.cgi';"
@@ -72,7 +92,7 @@
 
 - name: update configuration $Conf{TarClientCmd}
   lineinfile:
-    dest: /etc/backuppc/config.pl
+    dest: "/etc/{{ backuppc_directory }}/config.pl"
     backrefs: yes
     regexp: "^(\\$Conf{TarClientCmd}.*) root (\\$host.*)$"
     line: "\\1 backuppc \\2"
@@ -83,7 +103,7 @@
 - name: update configuration $Conf{TarClientRestoreCmd}
   lineinfile:
     backrefs: yes
-    dest: /etc/backuppc/config.pl
+    dest: "/etc/{{ backuppc_directory }}/config.pl"
     line: "\\1 backuppc \\2"
     regexp: "^(\\$Conf{TarClientRestoreCmd}.*) root (\\$host.*)$"
   tags:
@@ -93,7 +113,7 @@
 - name: update configuration $Conf{RsyncClientCmd}
   lineinfile:
     backrefs: yes
-    dest: /etc/backuppc/config.pl
+    dest: "/etc/{{ backuppc_directory }}/config.pl"
     line: "$Conf{RsyncClientCmd} = '$sshPath -q -x -l backuppc $host $rsyncPath $argList+';"
     regexp: "^\\$Conf{RsyncClientCmd}"
   tags:
@@ -103,7 +123,7 @@
 - name: update configuration $Conf{RsyncClientRestoreCmd}
   lineinfile:
     backrefs: yes
-    dest: /etc/backuppc/config.pl
+    dest: "/etc/{{ backuppc_directory }}/config.pl"
     line: "$Conf{RsyncClientRestoreCmd} = '$sshPath -q -x -l backuppc $host $rsyncPath $argList+';"
     regexp: "^\\$Conf{RsyncClientRestoreCmd}"
   tags:
@@ -113,9 +133,10 @@
 #  host setup
 - name: create hosts
   lineinfile:
-    dest: /etc/backuppc/hosts
+    dest: "/etc/{{ backuppc_directory }}/hosts"
     line: "{{ item.name }} 0 {{ item.contact|default('backuppc') }} {{ item.user|default('') }}"
-  with_items: backuppc_hosts
+  with_items: "{{ backuppc_hosts }}"
+  when: backuppc_hosts|length > 0
   notify:
     - restart backuppc
   tags:
@@ -125,12 +146,13 @@
 
 - name: create hosts configuration
   template:
-    dest: "/etc/backuppc/{{ item.name }}.pl"
+    dest: "/etc/{{ backuppc_directory }}/{{ item.name }}.pl"
     src: "backuppc-{{ item.os }}-{{ item.type }}.j2"
     owner: backuppc
     group: www-data
     mode: 0640
-  with_items: backuppc_hosts
+  with_items: "{{ backuppc_hosts }}"
+  when: backuppc_hosts|length > 0
   notify:
     - restart backuppc
   tags:
@@ -159,8 +181,8 @@
 
 - name: fetch generated public ssh key
   fetch:
-    src=/var/lib/backuppc/.ssh/id_rsa.pub
-    dest=/tmp/fetched
+    src: "/var/lib/ba{{ backuppc_directory }}ckuppc/.ssh/id_rsa.pub"
+    dest: /tmp/fetched
   when: ssh_key_generation|changed
   register: ssh_key_fetched
   tags:
@@ -169,15 +191,24 @@
     - clients
     - configuration
 
+- debug: var=backuppc_users
+
+- debug: var=item
+  with_items: "{{ backuppc_users }}"
+
+- debug: msg="{{ item.name }}:{{ item.pass }}"
+  with_items: "{{ backuppc_users }}"
+
 - name: add users to backuppc htpasswd file
   htpasswd:
-    path: /etc/backuppc/htpasswd
+    path: "/etc/{{ backuppc_directory }}/htpasswd"
     name: "{{ item.name }}"
     password: "{{ item.pass }}"
     owner: backuppc
-    group: www-data
+    group: "{{ backuppc_web_group }}"
     mode: 0640
-  with_items: backuppc_users
+  with_items: "{{ backuppc_users }}"
+  when: backuppc_users|length > 0
   tags:
     - backuppc
     - web site

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,6 +11,14 @@
     - backuppc
     - packages
 
+- name: adjust apache2 config
+  lineinfile:
+    name: /etc/apache2/ports.conf
+    regexp: '^Listen.*80$'
+    line: 'Listen localhost:80'
+    state: present
+  notify: restart apache2
+
 - name: set pool symlink
   file:
     src=/var/lib/backuppc/pc
@@ -31,7 +39,7 @@
     - restart backuppc
     - restart apache2
 
-#  host setup
+# host setup
 - name: create hosts
   template:
     src=hosts.j2
@@ -48,11 +56,12 @@
 
 - name: create hosts configuration
   template:
-    dest="/etc/backuppc/{{ item.name }}.pl"
-    src="backuppc-{{ item.os }}-{{ item.type }}.j2"
-    mode="u=rw,g=r,o="
-    owner="backuppc"
-    group="www-data"
+    dest: "/etc/backuppc/{{ item.name }}.pl"
+    src: "backuppc-{{ item.os }}-{{ item.type }}.j2"
+    mode: "u=rw,g=r,o="
+    owner: "backuppc"
+    group: "www-data"
+    backup: yes
   with_items: "{{ backuppc_hosts }}"
   notify:
     - restart backuppc
@@ -66,7 +75,7 @@
   user:
     name=backuppc
     generate_ssh_key=yes
-  register: ssh_key_generation
+  register: backuppc_server_ssh_key
   tags:
     - backuppc
     - ssh
@@ -76,7 +85,7 @@
   fetch:
     src=/var/lib/backuppc/.ssh/id_rsa.pub
     dest=/tmp/backuppc_ssh.pub
-  when: ssh_key_generation|changed
+  when: backuppc_server_ssh_key|changed
   register: ssh_key_fetched
   tags:
     - backuppc
@@ -91,10 +100,15 @@
     password: "{{ item.pass }}"
     owner: "backuppc"
     group: "www-data"
-    mode: 0640
+    mode: 'u=rw,g=r,o='
   with_items: "{{ backuppc_users }}"
   tags:
     - backuppc
     - website
     - credientals
+
+# loop over backuppc_hosts is done inside manage_hosts.yml
+- name: manage hosts
+  include: manage_hosts.yml
+  when: backuppc_manage_hosts
 

--- a/tasks/manage_hosts.yml
+++ b/tasks/manage_hosts.yml
@@ -1,0 +1,30 @@
+---
+- name: create user for backuppc
+  user:
+    name: backuppc
+    comment: "Backuppc User"
+    state: present
+  delegate_to: "{{ item.name }}"
+  with_items: "{{ backuppc_hosts }}"
+
+- name: copy ssh key for backuppc
+  authorized_key:
+    user: backuppc
+#    key: "{{ lookup('file', '/tmp/backuppc_ssh.pub/vagrant1/var/lib/backuppc/.ssh/id_rsa.pub') }}"
+    key: "{{ backuppc_server_ssh_key.ssh_public_key }}"
+    state: present
+    exclusive: yes
+  delegate_to: "{{ item.name }}"
+  with_items: "{{ backuppc_hosts }}"
+
+- name: copy sudoers.d config
+  copy:
+    src: backuppc.sudo
+    dest: /etc/sudoers.d/backuppc
+    mode: 'u=r,g=r,o='
+    owner: root
+    group: root
+    validate: visudo -cf %s
+  delegate_to: "{{ item.name }}"
+  with_items: "{{ backuppc_hosts }}"
+

--- a/templates/backuppc-linux-rsync.j2
+++ b/templates/backuppc-linux-rsync.j2
@@ -1,3 +1,4 @@
+{{ansible_managed|comment}}
 #
 # {{ item.name }} backup of everything as user backuppc
 #

--- a/templates/backuppc-linux-rsync.j2
+++ b/templates/backuppc-linux-rsync.j2
@@ -10,13 +10,14 @@ $Conf{BackupFilesExclude} = {
     '/cdrom',
     '/dvd',
     '/floppy',
+    '/var/lib/backuppc',
     '/mnt'
   ]
 };
 
-$Conf{RsyncClientCmd} = '$sshPath -q -x -l backuppc $host sudo $rsyncPath $argList+';
+$Conf{RsyncClientCmd} = '$sshPath -o StrictHostKeyChecking=no -q -x -l backuppc $host sudo $rsyncPath $argList+';
 
-$Conf{RsyncClientRestoreCmd} = '$sshPath -q -x -l backuppc sudo $host $rsyncPath $argList+';
+$Conf{RsyncClientRestoreCmd} = '$sshPath -o StrictHostKeyChecking=no -q -x -l backuppc sudo $host $rsyncPath $argList+';
 
 {% if item.ip_address is defined -%}
 $Conf{ClientNameAlias} = '{{ item.ip_address }}';

--- a/templates/backuppc-linux-rsync.j2
+++ b/templates/backuppc-linux-rsync.j2
@@ -19,7 +19,7 @@ $Conf{BackupFilesExclude} = {
 
 $Conf{RsyncClientCmd} = '$sshPath -o StrictHostKeyChecking=no -q -x -l backuppc $host sudo $rsyncPath $argList+';
 
-$Conf{RsyncClientRestoreCmd} = '$sshPath -o StrictHostKeyChecking=no -q -x -l backuppc sudo $host $rsyncPath $argList+';
+$Conf{RsyncClientRestoreCmd} = '$sshPath -o StrictHostKeyChecking=no -q -x -l backuppc $host sudo $rsyncPath $argList+';
 
 {% if item.ip_address is defined -%}
 $Conf{ClientNameAlias} = '{{ item.ip_address }}';

--- a/templates/backuppc-linux-rsync.j2
+++ b/templates/backuppc-linux-rsync.j2
@@ -12,6 +12,7 @@ $Conf{BackupFilesExclude} = {
     '/dvd',
     '/floppy',
     '/var/lib/backuppc',
+    '/var/lib/lxcfs/cgroup',
     '/mnt'
   ]
 };

--- a/templates/backuppc-linux-tar.j2
+++ b/templates/backuppc-linux-tar.j2
@@ -1,3 +1,4 @@
+{{ansible_managed|comment}}
 #
 # {{ item.name }} backup of everything as user backuppc
 #

--- a/templates/backuppc-mac-rsync.j2
+++ b/templates/backuppc-mac-rsync.j2
@@ -1,3 +1,4 @@
+{{ansible_managed|comment}}
 #
 # {{ item.name }} backup of everything as user backuppc
 #

--- a/templates/config.pl.j2
+++ b/templates/config.pl.j2
@@ -118,21 +118,21 @@ $Conf{UmaskMode} = 027;
 # you want BackupPC_nightly to run (eg: when you don't expect a lot
 # of regular backups to run).
 #
-$Conf{WakeupSchedule} = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23];
+$Conf{WakeupSchedule} = [12, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23];
 
 #
 # Maximum number of simultaneous backups to run.  If there
 # are no user backup requests then this is the maximum number
 # of simultaneous backups.
 #
-$Conf{MaxBackups} = 4;
+$Conf{MaxBackups} = 2;
 
 #
 # Additional number of simultaneous backups that users can run.
 # As many as $Conf{MaxBackups} + $Conf{MaxUserBackups} requests can
 # run at the same time.
 #
-$Conf{MaxUserBackups} = 4;
+$Conf{MaxUserBackups} = 2;
 
 #
 # Maximum number of pending link commands. New backups will only be

--- a/templates/config.pl.j2
+++ b/templates/config.pl.j2
@@ -2,7 +2,7 @@
 #
 # Configuration file for BackupPC.
 #
-# {{ ansible_managed }}
+{{ ansible_managed|comment }}
 #
 # DESCRIPTION
 #

--- a/templates/config.pl.j2
+++ b/templates/config.pl.j2
@@ -1189,7 +1189,7 @@ $Conf{RsyncClientPath} = '/usr/bin/rsync';
 # This setting only matters if $Conf{XferMethod} = 'rsync'.
 #
 #$Conf{RsyncClientCmd} = '$sshPath -q -x -l root $host $rsyncPath $argList+';
-$Conf{RsyncClientCmd} = '$sshPath -q -x -l backuppc $host sudo $rsyncPath $argList+';
+$Conf{RsyncClientCmd} = '$sshPath -o StrictHostKeyChecking=no -q -x -l backuppc $host sudo $rsyncPath $argList+';
 
 #
 # Full command to run rsync for restore on the client.  The following
@@ -1211,7 +1211,7 @@ $Conf{RsyncClientCmd} = '$sshPath -q -x -l backuppc $host sudo $rsyncPath $argLi
 # redirection and pipes; put that in a script if you need it.
 #
 #$Conf{RsyncClientRestoreCmd} = '$sshPath -q -x -l root $host $rsyncPath $argList+';
-$Conf{RsyncClientRestoreCmd} = '$sshPath -q -x -l backuppc $host sudo $rsyncPath $argList+';
+$Conf{RsyncClientRestoreCmd} = '$sshPath -o StrictHostKeyChecking=no -q -x -l backuppc $host sudo $rsyncPath $argList+';
 
 #
 # Share name to backup.  For $Conf{XferMethod} = "rsync" this should
@@ -1672,7 +1672,7 @@ $Conf{PingCmd} = '$pingPath -c 1 $host';
 # WAN or dialup connections the round-trip time will be typically more
 # than 20msec.  Tune if necessary.
 #
-$Conf{PingMaxMsec} = 20;
+$Conf{PingMaxMsec} = 30;
 
 #
 # Compression level to use on files.  0 means no compression.  Compression

--- a/templates/config.pl.j2
+++ b/templates/config.pl.j2
@@ -1893,7 +1893,7 @@ $Conf{EMailFromUserName} = '{{ backuppc_email_from_username }}';
 # handler this is either a plain name (eg: "admin") or a fully-qualified
 # name (eg: "admin@mydomain.com").
 #
-$Conf{EMailAdminUserName} = 'backuppc';
+$Conf{EMailAdminUserName} = 'backuppc@{{ backuppc_email_domain }}';
 
 #
 # Destination domain name for email sent to users.  By default

--- a/templates/config.pl.j2
+++ b/templates/config.pl.j2
@@ -307,11 +307,11 @@ $Conf{BackupPCUser} = 'backuppc';
 # a symbolic link to the new location, or mount the new BackupPC
 # store at the existing $Conf{TopDir} setting.
 #
-$Conf{TopDir}      = '/var/lib/backuppc';
-$Conf{ConfDir}     = '/etc/backuppc';
-$Conf{LogDir}      = '/var/lib/backuppc/log';
-$Conf{InstallDir}  = '/usr/share/backuppc';
-$Conf{CgiDir}      = '/usr/share/backuppc/cgi-bin';
+$Conf{TopDir}      = '/var/lib/{{ backuppc_directory }}';
+$Conf{ConfDir}     = '/etc/{{ backuppc_directory }}';
+$Conf{LogDir}      = '/var/lib/{{ backuppc_directory }}/log';
+$Conf{InstallDir}  = '/usr/share/{{ backuppc_directory }}';
+$Conf{CgiDir}      = '/usr/share/{{ backuppc_directory }}/cgi-bin';
 
 #
 # Whether BackupPC and the CGI script BackupPC_Admin verify that they
@@ -425,7 +425,7 @@ $Conf{IncrPeriod} = 0.97;
 #
 #    full 0 19 weeks old   \
 #    full 1 15 weeks old    >---  3 backups at 4 * $Conf{FullPeriod}
-#    full 2 11 weeks old   / 
+#    full 2 11 weeks old   /
 #    full 3  7 weeks old   \____  2 backups at 2 * $Conf{FullPeriod}
 #    full 4  5 weeks old   /
 #    full 5  3 weeks old   \
@@ -439,7 +439,7 @@ $Conf{IncrPeriod} = 0.97;
 #
 #    full 0 16 weeks old   \
 #    full 1 12 weeks old    >---  3 backups at 4 * $Conf{FullPeriod}
-#    full 2  8 weeks old   / 
+#    full 2  8 weeks old   /
 #    full 3  6 weeks old   \____  2 backups at 2 * $Conf{FullPeriod}
 #    full 4  4 weeks old   /
 #    full 5  3 weeks old   \
@@ -523,7 +523,7 @@ $Conf{IncrAgeMax}     = 30;
 #       $Conf{IncrKeepCnt} = 6;
 #       $Conf{IncrLevels}  = [1, 2, 3, 4, 5, 6];
 #
-# there will be up to 11 incrementals in this case: 
+# there will be up to 11 incrementals in this case:
 #
 #       backup #0  (full, level 0, oldest)
 #       backup #1  (incr, level 1)
@@ -860,7 +860,7 @@ $Conf{BackupZeroFilesIsFatal} = 1;
 #   - 'archive': host is a special archive host.  Backups are not done.
 #                An archive host is used to archive other host's backups
 #                to permanent media, such as tape, CDR or DVD.
-#               
+#
 #
 $Conf{XferMethod} = 'smb';
 
@@ -1274,12 +1274,12 @@ $Conf{RsyncdAuthRequired} = 1;
 # it to 1 (ie: 100%) means all files will be checked, but that is
 # not a desirable setting since you are better off simply turning
 # caching off (ie: remove the --checksum-seed option).
-#   
+#
 # The default of 0.01 means 1% (on average) of the files during a full
 # backup will have their cached checksum re-checked.
-#   
+#
 # This setting has no effect unless checksum caching is turned on.
-#   
+#
 $Conf{RsyncCsumCacheVerifyProb} = 0.01;
 
 #
@@ -1528,10 +1528,10 @@ $Conf{ArchivePar} = 0;
 #
 # Archive Size Split
 #
-# Only for file archives. Splits the output into 
+# Only for file archives. Splits the output into
 # the specified size * 1,000,000.
 # e.g. to split into 650,000,000 bytes, specify 650 below.
-# 
+#
 # If the value is 0, or if $Conf{ArchiveDest} is an existing file or
 # device (e.g. a streaming tape drive), this feature is disabled.
 #
@@ -1918,9 +1918,9 @@ $Conf{EMailUserDestDomain} = '@{{ backuppc_email_domain }}';
 #   To: $user$domain
 #   cc:
 #   Subject: $subj
-#   
+#
 #   Dear $userName,
-#   
+#
 #   This is a site-specific email message.
 #   EOF
 #
@@ -1946,9 +1946,9 @@ $Conf{EMailNotifyOldBackupDays} = 7.0;
 #   To: $user$domain
 #   cc:
 #   Subject: $subj
-#   
+#
 #   Dear $userName,
-#   
+#
 #   This is a site-specific email message.
 #   EOF
 #
@@ -1974,9 +1974,9 @@ $Conf{EMailNotifyOldOutlookDays} = 5.0;
 #   To: $user$domain
 #   cc:
 #   Subject: $subj
-#   
+#
 #   Dear $userName,
-#   
+#
 #   This is a site-specific email message.
 #   EOF
 #
@@ -2030,7 +2030,7 @@ $Conf{CgiAdminUsers}     = 'backuppc';
 #
 $Conf{CgiURL} = 'http://'.$Conf{ServerHost}.'/backuppc/index.cgi';
 
-#   
+#
 # Language to use.  See lib/BackupPC/Lang for the list of supported
 # languages, which include English (en), French (fr), Spanish (es),
 # German (de), Italian (it), Dutch (nl), Polish (pl), Portuguese
@@ -2116,8 +2116,8 @@ $Conf{CgiStatusHilightColor} = {
     Reason_no_ping                 => '#ffff99',
     Reason_backup_canceled_by_user => '#ff9900',
     Status_backup_in_progress      => '#66cc99',
-    Disabled_OnlyManualBackups     => '#d1d1d1',   
-    Disabled_AllBackupsDisabled    => '#d1d1d1',          
+    Disabled_OnlyManualBackups     => '#d1d1d1',
+    Disabled_AllBackupsDisabled    => '#d1d1d1',
 };
 
 #

--- a/templates/hosts.j2
+++ b/templates/hosts.j2
@@ -1,6 +1,6 @@
 #============================================================= -*-perl-*-
 #
-# {{ansible_managed}}
+{{ansible_managed|comment}}
 #
 # Host file list for BackupPC.
 #
@@ -13,4 +13,3 @@ host        dhcp    user    moreUsers     # <--- do not edit this line
 {% for host in backuppc_hosts|sort %}
 {{ host.name }} 0 {{ host.contact|default('backuppc') }} {{ host.user|default('') }} #
 {% endfor %}
-

--- a/tests/Vagrantfile
+++ b/tests/Vagrantfile
@@ -17,11 +17,28 @@ Vagrant.configure(2) do |config|
     end
   end
 
+  config.vm.define "ubuntu-xenial" do |vagrant1|
+    vagrant1.vm.box = "ubuntu/xenial64"
+    vagrant1.vm.synced_folder ".", "/vagrant", disabled: true
+    vagrant1.ssh.forward_agent = true
+    vagrant1.vm.network "forwarded_port", guest: 80, host: 18080
+
+    vagrant1.vm.provision "shell",
+      inline: "apt install -y python-minimal"
+
+    vagrant1.vm.provision "ansible" do |ansible|
+      ansible.playbook = "test.yml"
+    end
+  end
+
   config.vm.define "ubuntu-bionic" do |vagrant1|
     vagrant1.vm.box = "ubuntu/bionic64"
     vagrant1.vm.synced_folder ".", "/vagrant", disabled: true
     vagrant1.ssh.forward_agent = true
-    vagrant1.vm.network "forwarded_port", guest: 80, host: 28080
+    vagrant1.vm.network "forwarded_port", guest: 80, host: 18080
+
+    vagrant1.vm.provision "shell",
+      inline: "apt install -y python-minimal"
 
     vagrant1.vm.provision "ansible" do |ansible|
       ansible.playbook = "test.yml"
@@ -32,7 +49,7 @@ Vagrant.configure(2) do |config|
     vagrant1.vm.box = "centos/7"
     vagrant1.vm.synced_folder ".", "/vagrant", disabled: true
     vagrant1.ssh.forward_agent = true
-    vagrant1.vm.network "forwarded_port", guest: 80, host: 38080
+    vagrant1.vm.network "forwarded_port", guest: 80, host: 18080
 
     vagrant1.vm.provision "ansible" do |ansible|
       ansible.playbook = "test.yml"

--- a/tests/Vagrantfile
+++ b/tests/Vagrantfile
@@ -6,11 +6,33 @@ Vagrant.configure(2) do |config|
   # For a complete reference, please see the online documentation at
   # https://docs.vagrantup.com.
 
-  config.vm.define "vagrant1" do |vagrant1|
+  config.vm.define "ubuntu-trusty" do |vagrant1|
     vagrant1.vm.box = "ubuntu/trusty64"
     vagrant1.vm.synced_folder ".", "/vagrant", disabled: true
     vagrant1.ssh.forward_agent = true
-    vagrant1.vm.network "forwarded_port", guest: 80, host: 8080
+    vagrant1.vm.network "forwarded_port", guest: 80, host: 18080
+
+    vagrant1.vm.provision "ansible" do |ansible|
+      ansible.playbook = "test.yml"
+    end
+  end
+
+  config.vm.define "ubuntu-bionic" do |vagrant1|
+    vagrant1.vm.box = "ubuntu/bionic64"
+    vagrant1.vm.synced_folder ".", "/vagrant", disabled: true
+    vagrant1.ssh.forward_agent = true
+    vagrant1.vm.network "forwarded_port", guest: 80, host: 28080
+
+    vagrant1.vm.provision "ansible" do |ansible|
+      ansible.playbook = "test.yml"
+    end
+  end
+
+  config.vm.define "centos7" do |vagrant1|
+    vagrant1.vm.box = "centos/7"
+    vagrant1.vm.synced_folder ".", "/vagrant", disabled: true
+    vagrant1.ssh.forward_agent = true
+    vagrant1.vm.network "forwarded_port", guest: 80, host: 38080
 
     vagrant1.vm.provision "ansible" do |ansible|
       ansible.playbook = "test.yml"

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,7 +1,8 @@
 ---
 - hosts:
     - ubuntu-trusty
-    - ubunu-bionic
+    - ubuntu-xenial
+    - ubuntu-bionic
     - centos7
   become: True
   remote_user: root

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,5 +1,8 @@
 ---
-- hosts: vagrant1
+- hosts:
+    - ubuntu-trusty
+    - ubunu-bionic
+    - centos7
   become: True
   remote_user: root
   roles:

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,0 +1,10 @@
+---
+backuppc_web_group: 'www-data'
+backuppc_directory: 'backuppc'
+backuppc_httpd_listen_conf: '/etc/apache2/ports.conf'
+backuppc_httpd_service_name: 'apache2'
+backuppc_packages:
+  - apache2
+  - backuppc
+  - rsync
+  - python-passlib # ansible htpasswd support

--- a/vars/FreeBSD.yml
+++ b/vars/FreeBSD.yml
@@ -1,0 +1,5 @@
+---
+backuppc_web_group: 'www'
+backuppc_directory: '/etc/backuppc' #test me
+backuppc_httpd_listen_conf: '/usr/local/etc/httpd/ports.conf' #test me
+backuppc_packages: [] # test me

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,0 +1,12 @@
+---
+backuppc_web_group: 'apache'
+backuppc_directory: 'BackupPC'
+backuppc_httpd_listen_conf: '/etc/httpd/conf/httpd.conf'
+backuppc_httpd_service_name: 'httpd'
+backuppc_packages:
+  - httpd
+  - backuppc
+  - rsync
+  - nfs-utils
+  - bzip2
+  - python-passlib # ansible htpasswd support

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,0 +1,2 @@
+---
+backuppc_directory: "{{ [ansible_os_family]|map('extract', {'Debian': 'backuppc', 'RedHat': 'BackupPC'})|list|first }}"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,1 @@
 ---
-backuppc_directory: "{{ [ansible_os_family]|map('extract', {'Debian': 'backuppc', 'RedHat': 'BackupPC'})|list|first }}"


### PR DESCRIPTION
Hello

This will add the option to also mange the "clients" defined in backuppc. Enabled via backuppc_manage_hosts: yes, it will login to those servers and create backuppc user and setup sudo rules.

I also did some sane defaults in templates for new hosts.

This also includes some work from @mat-green for CentOS support. I worked on it to make it work with tests for Ubuntu Trusty, Xenial and Bionic as well as on CentOS7.

This obsoletes PR #2
